### PR TITLE
something something side effects of changing the current working dire…

### DIFF
--- a/drl_hw1/utils/train_agent.py
+++ b/drl_hw1/utils/train_agent.py
@@ -28,6 +28,8 @@ def train_agent(job_name, agent,
     np.random.seed(seed)
     if os.path.isdir(job_name) == False:
         os.mkdir(job_name)
+
+    previous_dir = os.getcwd()
     os.chdir(job_name) # important! we are now in the directory to save data
     if os.path.isdir('iterations') == False: os.mkdir('iterations')
     if os.path.isdir('logs') == False and agent.save_logs == True: os.mkdir('logs')
@@ -84,3 +86,4 @@ def train_agent(job_name, agent,
     if agent.save_logs:
         agent.logger.save_log('logs/')
         make_train_plots(log=agent.logger.log, keys=plot_keys, save_loc='logs/')
+    os.chdir(previous_dir)


### PR DESCRIPTION
expected behavior: every call to train_agent(job_name=a_job_name, ...) produces a log folder in the directory of the calling module.

actual behavior: subsequent calls to train_agent(job_name=a_job_name,...) produces nested folders as in:

`for job_name in ['bob', 'the', 'builder']:
    train_agent(job_name=job_name, ...)
`

produces the folders:

bob
|_the
   |_builder


this commit fixes the issue in a hacky way. I suggest to the authors to avoid using os.chdir and instead just navigate from the cwd.